### PR TITLE
Support for Delphi Alexandria 11.1

### DIFF
--- a/Dockerfile.11.1
+++ b/Dockerfile.11.1
@@ -1,0 +1,28 @@
+FROM ubuntu:20.04
+
+LABEL authors="Herson Melo <hersonpc@gmail.com>, Alessandro Bartoli <alessandro@bartolilab.it>"
+
+WORKDIR /app
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y install joe wget p7zip-full curl unzip build-essential zlib1g-dev libcurl4-gnutls-dev libncurses5 && \
+    apt-get -y install mysecureshell && \
+    apt-get -y autoremove && \
+    apt-get -y autoclean
+
+# RAD Studio Alexandria (11.1)
+RUN wget https://altd.embarcadero.com/releases/studio/22.0/111/LinuxPAServer22.0.tar.gz
+
+RUN \
+    tar -xvf LinuxPAServer22.0.tar.gz && \
+    rm LinuxPAServer22.0.tar.gz && \
+    cd PAServer-22.0
+
+WORKDIR /app/PAServer-22.0
+
+CMD ["/app/PAServer-22.0/paserver", "-password="]
+
+EXPOSE 64211
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Embarcadero PAServer in a Docker Container
 Ambiente de compilação Delphi em Linux
 
 ## Running docker images
+
 https://hub.docker.com/r/hersonpc/paserver
 
 Para rodar o PAServer como um container do Docker, basta exectar o comando com a versão adequada para a versão do Delphi que estiver sendo executada no ambiente de desemvolvimento.
@@ -30,6 +31,9 @@ docker run -it -d --name paserver -p 64211:64211 hersonpc/paserver:10.4.1
 
 ### RAD Studio Sydney (10.4.2)
 docker run -it -d --name paserver -p 64211:64211 hersonpc/paserver:10.4.2
+
+### RAD Studio Alexandria (11.1)
+docker run -it -d --name paserver -p 64211:64211 hersonpc/paserver:11.1
 ```
 
 ## Building docker images
@@ -57,8 +61,10 @@ docker build -f Dockerfile.10.4.1 -t hersonpc/paserver:10.4.1 .
 
 ### RAD Studio Sydney (10.4.2)
 docker build -f Dockerfile.10.4.2 -t hersonpc/paserver:10.4.2 .
-```
 
+### RAD Studio Alexandria (11.1)
+docker build -f Dockerfile.11.1 -t hersonpc/paserver:11.1 .
+```
 
 ### To push local images to docker hub
 


### PR DESCRIPTION
- Add "libncurses5" to the linux packages list.
- Replaced 'maintainer' with 'authors' in 'Dockerfile.11.1'.